### PR TITLE
Add 7/Seven Chain Node — EVM perpetual futures blockchain (Chain ID: 70007)

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,3 +120,5 @@ Other awesome collections.
 * [FireWall.X — 强大的 EOS 智能合约防火墙](https://firewallx.io/)
 * [FireWall.X GitHub](https://github.com/firewall-x)
 * [Open of SlowMist](https://github.com/slowmist/)
+
+- [7/Seven Chain Node](https://github.com/umairkhan2582/seven-chain-node) - Validator node for 7/Seven Chain (Chain ID: 70007), an EVM-compatible blockchain (BSC/Parlia fork) powering [TheSeven.meme](https://theseven.meme) — perpetual futures exchange with 100+ pairs, up to 2001× leverage, zero fees.


### PR DESCRIPTION
## 7/Seven Chain Node

Adding [7/Seven Chain Node](https://github.com/umairkhan2582/seven-chain-node) to this list.

**What is it?**
7/Seven Chain is an EVM-compatible blockchain (BSC/Parlia, Chain ID: 70007) powering [TheSeven.meme](https://theseven.meme):
- 100+ trading pairs | **2001× leverage** | **Zero fees** | On-chain settlement

**Links:**
- Repo: https://github.com/umairkhan2582/seven-chain-node | Exchange: https://theseven.meme
- RPC: https://rpc.theseven.meme | Chain ID: 70007
- Explorer: https://theseven.meme/blockchain/explorer